### PR TITLE
Cambia forma de visualizar adjudicaciones

### DIFF
--- a/static/js/frontend.MapController.js
+++ b/static/js/frontend.MapController.js
@@ -66,7 +66,7 @@
         .controller('MapController', ['$scope', 'backEnd', '$filter',
             '$routeParams', '$rootScope', '$timeout', '$location',
             function ($scope, backEnd, $filter, $routeParams, $rootScope, $timeout, $location) {
-                $scope.reportar = function(prioridad, tipo) {
+                $scope.reportar = function (prioridad, tipo) {
                     if (typeof (window.reportar) === 'function') {
                         var institucion = $scope.infoData.instituciones.filter(function (obj) {
                             return obj.codigo_institucion == $scope.institucion_actual;
@@ -305,7 +305,7 @@
                     loading(true);
                     var params = {};
 
-                    if ($scope.otrosSeleccionados.check){
+                    if ($scope.otrosSeleccionados.check) {
                         var otros = $scope.otrosSeleccionados;
                         params.reportadas = otros.reportadas;
                         //params.adjudicaciones = otros.adjudicaciones;
@@ -341,7 +341,7 @@
                             backEnd.filtros.query(params, function (data) {
                                 $scope.filtroArray = data;
                                 // Estos filtros no deberian cachearse
-                                if(!$scope.otrosSeleccionados.check)
+                                if (!$scope.otrosSeleccionados.check)
                                     $scope.filtros[gen_hash(params)] = data;
                                 if (Storage !== 'undefined') {
                                     localStorage.setItem('filtros', JSON.stringify($scope.filtros));
@@ -480,6 +480,25 @@
                     $scope.periodo = 2015;
                     var establecimiento_nuevo = {};
                     var instituciones_nuevas = [];
+
+                    // Establecer Planificaciones y Adjudicaciones solo si son necesarias
+                    var setInfoDNCP = function (planificaciones, adjudicaciones) {
+                        var planificacion_actuales = new Array();
+                        // No se guarda una planificación que cuyo id_llamado ya exista en alguna adjudicación
+                        for (var p in planificaciones) {
+                            if ($.inArray(planificaciones[p].id_llamado, adjudicaciones.map(
+                                    function (el) {
+                                        return el.id_llamado;
+                                    }
+                                )) < 0) {
+                                planificacion_actuales.push(planificaciones[p]);
+                            }
+                        }
+
+                        $scope.planificaciones_actual = planificacion_actuales;
+                        $scope.adjudicaciones_actual = adjudicaciones;
+                    }
+
                     backEnd.establecimiento.get({
                         id: id
                     }, function (value) {
@@ -506,15 +525,17 @@
                                 var t = $scope.infoData.instituciones;
                                 for (var i in t) {
                                     if (t[i].codigo_institucion === idInstitucion) {
-                                        $scope.planificaciones_actual = t[i].planificaciones;
-                                        $scope.adjudicaciones_actual = t[i].adjudicaciones;
+                                        setInfoDNCP(t[i].planificaciones, t[i].adjudicaciones);
+                                        //$scope.planificaciones_actual = t[i].planificaciones;
+                                        //$scope.adjudicaciones_actual = t[i].adjudicaciones;
                                     }
                                 }
                             } else {
                                 $scope.institucion_actual = instituciones_nuevas[
                                     0].codigo_institucion;
-                                $scope.planificaciones_actual = instituciones_nuevas[0].planificaciones;
-                                $scope.adjudicaciones_actual = instituciones_nuevas[0].adjudicaciones;
+                                //$scope.planificaciones_actual = instituciones_nuevas[0].planificaciones;
+                                //$scope.adjudicaciones_actual = instituciones_nuevas[0].adjudicaciones;
+                                setInfoDNCP(instituciones_nuevas[0].planficaciones, instituciones_nuevas[0].adjudicaciones);
                             }
                             $timeout(function () {
                                 $scope.map.invalidateSize();

--- a/templates/denuncia.html
+++ b/templates/denuncia.html
@@ -156,7 +156,6 @@
         }
     }, {
         onSuccess: function(){
-            console.log('EXITO!!');
             $.ajax({
                 url: '{% url 'reportar' %}',
                 type: 'POST',

--- a/templates/map.html
+++ b/templates/map.html
@@ -128,6 +128,7 @@
                         </div>
                         <div class="four wide column"/>
                         <div class="four wide column right aligned">
+                            <!-- verificar el permiso para agregar información de fonacide -->
                             <div class="fluid ui button teal"
                                     {% if 'openfonacide.verificar_estado' in user.get_all_permissions or 'openfonacide.cambiar_estado' in user.get_all_permissions %}
                                  ng-click="agregarAdjudicacion()" {% endif %}> Agregar Adjudicacion
@@ -141,7 +142,7 @@
                                 <h4 ng-if="adjudicaciones_actual.length == 0 && planificaciones_actual == 0">No hay adjudicaciones</h4>
                             <ul>
                                 <li ng-repeat=" p in planificaciones_actual">{$ p.nombre_licitacion $} - Fue planificada
-                                    para realizarse en la fecha estimada <i>{$ p.fecha_estimada $}</i>.
+                                    para realizarse en la fecha estimada <i>{$ p.fecha_estimada $}</i>. Categoría: <i>{$ p.categoria $}</i>.
                                     <a href="https://www.contrataciones.gov.py/datos/visualizaciones/etapas-licitacion-emb?id_llamado={$ p.id_llamado $}"
                                        target="_blank"> Ver estado </a>
                                 </li>
@@ -159,7 +160,7 @@
                             </ul>
                             <ul>
                                 <li ng-repeat=" a in adjudicaciones_actual">{$ a.nombre_licitacion $} - Fue adjudicada
-                                    por un monto de {$ a.moneda $} <span class="ui teal label">{$ formatoDinero(a.monto_total_adjudicado) $}</span>
+                                    por un monto de {$ a.moneda $} <span class="ui teal label">{$ formatoDinero(a.monto_total_adjudicado) $}</span>. Categoría: <i>{$ a.categoria $}</i>
                                     <a href="https://www.contrataciones.gov.py/datos/visualizaciones/etapas-licitacion-emb?id_llamado={$ a.id_llamado $}"
                                        target="_blank"> Ver estado </a>
                                     <!-- en la fecha <i>{$ a.fecha_publicacion $}</i>. -->

--- a/templates/microplanificacion-proceso.html
+++ b/templates/microplanificacion-proceso.html
@@ -1,4 +1,4 @@
-
+{% load staticfiles %}
 
 <style type="text/css">
 
@@ -291,7 +291,7 @@ Informe del proceso de implementación de la Fase II, identificando los logros, 
 
                     <div class="ui segment active tab" data-tab="asignacion/descripcion">
                       <div class="ui large header">Descripción</div>
-                       <img src="/static/images/asignacion.png" class="ui image medium  right floated asignacion-foto">
+                       <img src="{% static 'images/asignacion.png' %}" class="ui image medium  right floated asignacion-foto">
                       <p>En esta etapa se asignan los recursos financieros para el funcionamiento de las secciones, nivel/modalidad y/o apertura de una institución educativa para el año lectivo escolar, previo análisis de los requerimientos a nivel nacional, departamental y asignación de cupos departamentales conforme a la disponibilidad presupuestaria. </p>
 
                     <p>En lo que respecta a infraestructura, equipamiento y almuerzo escolar serán financiados con fondos del FONACIDE y administrados por los gobiernos municipales y departamentales, según establece los Art. 37 y 38 del Decreto 10504/13. </p>
@@ -365,7 +365,7 @@ Asimismo, se realiza, la reasignación de los recursos humanos, asignación de c
 
                     <div class="ui segment active tab" data-tab="evaluacion/descripcion">
                       <div class="ui large header">Descripción</div>
-                       <img src="/static/images/evaluacion.png" class="ui image medium  right floated evaluacion-foto">
+                       <img src="{% static 'images/evaluacion.png' %}" class="ui image medium  right floated evaluacion-foto">
                       <p>La evaluación es un proceso que permite a los tomadores de decisiones identificar el grado de cumplimiento de los objetivos propuestos del programa o proyecto, los aspectos que lo hicieron posible, así como los factores que lo dificultaron. Su importancia radica en profundizar el análisis sobre las causas que afectan negativamente la implementación del proceso a fin de proponer alternativas de solución, en este sentido, debe centrarse en identificar y explicar las causas a fin de facilitar las recomendaciones que permitan mejorar lo que se está evaluando y no limitarse a una simple valoración.</p>
                     </div>
 

--- a/templates/microplanificacion.html
+++ b/templates/microplanificacion.html
@@ -58,7 +58,7 @@
 
         <div class="ui segment tab contenido-explicacion " style="min-height: 300px;"  data-tab="proceso">
 
-           <img src="/static/images/proceso-micro.png" class="ui image medium foto-proceso right floated ">
+           <img src="{% static 'images/proceso-micro.png' %}" class="ui image medium foto-proceso right floated ">
         El proceso de Micro planificación se compone de las siguientes fases:
         <ul>
           <li>Fase I: Diagnóstico educativo departamental</li>


### PR DESCRIPTION
Ahora el listado de adjudicaciones, muestra la planificación
solo si no ha sido adjudicada a nadie aun. En caso de
haber adjudicación ya se muestra solo la adjudicación.

Se agrega ademas información de la categoría de la
planificación/adjudicacion además del enlace correspondiente a
la visualicación de licitaciones en el sitio del DNCP

Signed-off-by: Diego Ramírez <syncrhonous@gmail.com>